### PR TITLE
Avoid deadlocks in synchronous calling code

### DIFF
--- a/Mailgun/Service/MessageService.cs
+++ b/Mailgun/Service/MessageService.cs
@@ -61,7 +61,7 @@ namespace Mailgun.Service
 
 
                 //set the client uri
-                return await client.PostAsync(buildUri.ToString(), message.AsFormContent());
+                return await client.PostAsync(buildUri.ToString(), message.AsFormContent()).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
Libraries should not assume the calling code requires the same context
